### PR TITLE
feat: Add responsive layout and theme enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
             transition: border-color 0.5s ease, background-color 0.5s ease;
         }
         .number-box {
-            background-color: #e9e9e9;
+            background-color: #fff;
+            border: 1px solid #ddd;
             text-align: center;
             padding: 8px 0;
             border-radius: 4px;
@@ -78,7 +79,7 @@
             font-weight: bold;
         }
         .number-box:hover {
-            background-color: #ddd;
+            background-color: #f0f0f0;
         }
         .number-box.selected {
             background-color: #4CAF50;
@@ -723,6 +724,9 @@
         .celuapuestas-theme .logo {
             filter: brightness(0) invert(1) sepia(1) hue-rotate(280deg) saturate(1000%) brightness(1.2);
         }
+        .cosmic-theme .logo, .neon-theme .logo, .matrix-theme .logo {
+            filter: invert(1);
+        }
         .container.celuapuestas-theme {
             background-color: #20202d; /* Color del panel */
             border: 1px solid #333344;
@@ -943,6 +947,16 @@
         }
         .matrix-theme .footer {
             color: #0f0;
+        }
+
+        /* --- RESPONSIVE DESIGN --- */
+        @media (min-width: 768px) {
+            .container {
+                max-width: 900px;
+            }
+            #numbers-container {
+                grid-template-columns: repeat(15, 1fr);
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
This commit introduces several improvements based on user feedback:

1.  **Responsive Layout:** The main container is now wider on screens larger than 768px, providing a better desktop experience. The grid of numbers also expands to fill the additional space.

2.  **Theme-Specific Logo:** A CSS `filter` is now applied to the logo on all dark themes (`cosmic`, `neon`, `matrix`) to ensure it remains visible and stylish.

3.  **Default Theme Polish:** The number boxes in the default theme now have a white background with a light border for better contrast and a cleaner look.