### PR TITLE
Añade un nuevo tema oscuro llamado 'Simple Dark' y actualiza el pie d…

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,6 +856,125 @@
             color: #666;
         }
 
+        /* --- ESTILOS TEMA SIMPLE DARK (NUEVO) --- */
+        body.simple-dark-theme {
+            background-color: #121212;
+            color: #e0e0e0;
+        }
+        .simple-dark-theme .logo {
+            filter: invert(1);
+        }
+        .container.simple-dark-theme {
+            background-color: #1e1e1e;
+            border: 1px solid #333;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.5);
+        }
+        .simple-dark-theme h1 {
+            color: #7aa5d2; /* Azul apagado */
+        }
+        .simple-dark-theme label {
+            color: #e0e0e0;
+        }
+        .simple-dark-theme input[type="text"] {
+            background-color: #252525;
+            color: #e0e0e0;
+            border: 1px solid #444;
+        }
+        .simple-dark-theme #numbers-container {
+            background-color: #121212;
+            border: 1px solid #444;
+        }
+        .simple-dark-theme .number-box {
+            background-color: #2c2c2c;
+            color: #e0e0e0;
+            border: 1px solid #444;
+        }
+        .simple-dark-theme .number-box:hover {
+            background-color: #3e3e3e;
+        }
+        .simple-dark-theme .number-box.selected {
+            background-color: #c5a365; /* Oro suave */
+            color: #121212;
+            box-shadow: 0 0 5px #c5a365;
+        }
+        .simple-dark-theme .number-box.assigned {
+            background-color: #222222;
+            color: #555;
+            text-decoration-color: #555;
+        }
+        .simple-dark-theme button {
+            font-weight: bold;
+        }
+        .simple-dark-theme #add-button { background-color: #7aa5d2; color: #121212; }
+        .simple-dark-theme #add-button:hover { background-color: #5c8bb8; }
+        .simple-dark-theme #sorteo-button { background-color: #b86a6a; } /* Rojo apagado */
+        .simple-dark-theme #sorteo-button:hover { background-color: #a35c5c; }
+        .simple-dark-theme #clear-button { background-color: #8c8c8c; }
+        .simple-dark-theme #clear-button:hover { background-color: #7a7a7a; }
+        .simple-dark-theme .add-numbers-group button, .simple-dark-theme .range-buttons button {
+            background-color: #4a4a58;
+            color: #f0f0f0;
+        }
+        .simple-dark-theme .add-numbers-group button:hover, .simple-dark-theme .range-buttons button:hover {
+            background-color: #5a5a68;
+        }
+        .simple-dark-theme #results-container, .simple-dark-theme #history-container {
+            background-color: #1e1e1e;
+            border: 1px solid #333;
+        }
+        .simple-dark-theme .person-entry, .simple-dark-theme .history-entry {
+            border-bottom: 1px solid #333;
+        }
+        .simple-dark-theme .person-name {
+            color: #7aa5d2;
+        }
+        .simple-dark-theme .action-button {
+            color: #e0e0e0;
+        }
+        .simple-dark-theme .action-button:hover {
+            color: #c5a365;
+        }
+        .simple-dark-theme #ganador-container h2 {
+            color: #c5a365;
+        }
+        .simple-dark-theme #ganador-nombre {
+            color: #b86a6a;
+        }
+        .simple-dark-theme #ganador-numero {
+            color: #7aa5d2;
+        }
+        .simple-dark-theme #countdown-timer {
+            color: #c5a365;
+        }
+        .simple-dark-theme #theme-selector {
+            background-color: #2c2c2c;
+            color: #e0e0e0;
+            border-color: #4a4a58;
+        }
+        .simple-dark-theme .footer {
+            color: #666;
+        }
+        .simple-dark-theme .number-box.resaltado {
+            border: 3px solid #b86a6a;
+            box-shadow: 0 0 10px #b86a6a;
+        }
+        .simple-dark-theme #save-data-button, .simple-dark-theme #load-data-button {
+             background-color: #4a4a58;
+        }
+        .simple-dark-theme #save-data-button:hover, .simple-dark-theme #load-data-button:hover {
+            background-color: #3a3a48;
+        }
+        .simple-dark-theme #save-code-container {
+            background-color: #2c2c2c;
+            border-color: #4a4a58;
+        }
+        .simple-dark-theme #save-code-container h4 {
+            color: #e0e0e0;
+        }
+        .simple-dark-theme #saved-code {
+            color: #c5a365;
+        }
+
         /* --- ESTILOS TEMA MATRIX --- */
         #matrix-canvas {
             display: none; /* Oculto por defecto */
@@ -970,6 +1089,7 @@
                 <option value="neon">Neon Party</option>
                 <option value="pastel">Pastel Dreams</option>
                 <option value="celuapuestas">CeluApuestas</option>
+                <option value="simple-dark">Simple Dark</option>
                 <option value="matrix">Matrix</option>
             </select>
         </div>
@@ -1026,7 +1146,7 @@
         </div>
 
         <p class="footer">
-            <a href="https://www.redpilar.com.ar" target="_blank">RedPilar.com.ar</a> - Sorteo Digital
+            <a href="https://www.redpilar.com.ar" target="_blank">RedPilar.com.ar</a> - Sorteo Digital - design by Clau
         </p>
 
     </div>


### PR DESCRIPTION
…e página.

- Se ha creado un nuevo tema CSS llamado 'simple-dark-theme' con una paleta de colores oscuros y de bajo contraste para mejorar la comodidad visual.
- Se ha añadido la opción 'Simple Dark' al selector de temas para que los usuarios puedan activarlo.
- Se ha actualizado el pie de página para incluir el texto 'design by Clau' según lo solicitado.