### PR TITLE
Fix: Make the 'sortear' button visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@
             color: #5e548e;
             border-color: #b57edc;
         }
-        .hide-on-edit-mode {
+        body.edit-mode .hide-on-edit-mode {
             display: none;
         }
         /* ESTILOS PARA LOS BOTONES DE GUARDAR/CARGAR */


### PR DESCRIPTION
The 'sortear' button was present in the HTML but hidden by a CSS rule (`.hide-on-edit-mode { display: none; }`). This made the button invisible at all times.

This change corrects the CSS selector to `body.edit-mode .hide-on-edit-mode`, which correctly hides the button only when the application is in edit mode. This makes the button visible by default, addressing the user's report that the button was missing.