### PR TITLE
Corrige el manejador de clics para números y añade selección individual

### DIFF
--- a/index.html
+++ b/index.html
@@ -1421,12 +1421,34 @@
 
                 numberBox.addEventListener('click', () => {
                     if (assignedNumbers.has(num)) {
-                        return; // Do nothing for assigned numbers
+                        // Si el número ya está asignado, no hacemos nada.
+                        return;
                     }
 
-                    // If a free number is clicked, open the modal
-                    if (!selectedNumbers.has(num)) {
-                         openFreeNumberModal(num);
+                    // Comportamiento dual: seleccionar vs. gestionar.
+                    // Si hay un nombre en el campo de texto, el clic selecciona/deselecciona.
+                    // Si no hay nombre, el clic abre el modal de gestión.
+                    const isAddingParticipant = personNameInput.value.trim() !== '';
+
+                    if (isAddingParticipant) {
+                        // Modo selección: El clic selecciona o deselecciona el número.
+                        if (selectedNumbers.has(num)) {
+                            selectedNumbers.delete(num);
+                            numberBox.classList.remove('selected');
+                        } else {
+                            selectedNumbers.add(num);
+                            numberBox.classList.add('selected');
+                        }
+                    } else {
+                        // Modo gestión: El clic abre el modal para números libres.
+                        // Esto soluciona el problema original del usuario.
+                        if (selectedNumbers.has(num)) {
+                            // Si el número estaba seleccionado (ej. con +10), se deselecciona
+                            // para evitar conflictos antes de abrir el modal.
+                            selectedNumbers.delete(num);
+                            numberBox.classList.remove('selected');
+                        }
+                        openFreeNumberModal(num);
                     }
                 });
                 numbersContainer.appendChild(numberBox);


### PR DESCRIPTION
Se ha modificado la lógica del evento de clic en los números para solucionar un conflicto entre la selección de números para nuevos participantes y la gestión de números libres (eliminar o asignar a existentes).

Ahora, el comportamiento es dual:
- Si el campo de nombre de participante está vacío, un clic en un número libre abre un modal de gestión.
- Si se está escribiendo un nombre, el clic permite seleccionar y deseleccionar números individualmente.

Esto resuelve el bug reportado por el usuario y mejora significativamente la usabilidad de la aplicación.