### PR TITLE
Fix: Unable to add new participants

### DIFF
--- a/index.html
+++ b/index.html
@@ -1461,6 +1461,14 @@
                 alert('Por favor, introduce un nombre.');
                 return;
             }
+
+            // Sincronizar selectedNumbers desde el DOM para asegurar consistencia
+            selectedNumbers.clear();
+            const selectedBoxes = numbersContainer.querySelectorAll('.number-box.selected');
+            selectedBoxes.forEach(box => {
+                selectedNumbers.add(parseInt(box.dataset.number, 10));
+            });
+
             if (selectedNumbers.size === 0) {
                 alert('Por favor, selecciona al menos un número.');
                 return;


### PR DESCRIPTION
The user reported being unable to add new participants because the application indicated that no number was selected, even though they had selected one.

This was due to a desynchronization between the visual state of the selected numbers and the application's internal state.

The fix involves re-synchronizing the selected numbers from the DOM just before validation in the `addParticipant` function. This ensures the application always has the correct state and resolves the issue.