### PR TITLE
Remove the automatic loading of numbers when scrolling.

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,15 +919,6 @@
         modalDeleteButton.addEventListener('click', deleteSingleNumber);
         modalAssignButton.addEventListener('click', assignNumberToParticipant);
 
-        numbersContainer.addEventListener('scroll', () => {
-            if (isLoading) return;
-
-            if (numbersContainer.scrollTop + numbersContainer.clientHeight >= numbersContainer.scrollHeight - 5) {
-                isLoading = true;
-                addMoreNumbers(100);
-                isLoading = false;
-            }
-        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
The previous implementation automatically loaded 100 more numbers when the user scrolled to the bottom of the number container. This was not desired by the user.

This change removes the 'scroll' event listener that triggered the loading of more numbers. The user can still add more numbers manually using the existing "+10 Números" button.