### PR TITLE
Implement persistence for the list of available numbers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,7 +802,8 @@
         function saveToLocalStorage() {
             const data = {
                 participants: participants,
-                assignedNumbers: Array.from(assignedNumbers)
+                assignedNumbers: Array.from(assignedNumbers),
+                allNumbers: allNumbers
             };
             const compressedData = btoa(JSON.stringify(data));
             localStorage.setItem('raffleData', compressedData);
@@ -815,13 +816,22 @@
                     const decompressedData = JSON.parse(atob(compressedData));
                     participants = decompressedData.participants || [];
                     assignedNumbers = new Set(decompressedData.assignedNumbers || []);
-                
-                    renderNumbers();
+                    allNumbers = decompressedData.allNumbers || [];
+
+                    if (allNumbers.length === 0) {
+                        generateNumbers(100);
+                    } else {
+                        renderNumbers();
+                    }
                     renderParticipants();
+
                 } catch (e) {
                     console.error("Error al analizar los datos de localStorage, reseteando. Error:", e);
                     localStorage.removeItem('raffleData');
+                    generateNumbers(100);
                 }
+            } else {
+                generateNumbers(100);
             }
         }
 
@@ -899,7 +909,6 @@
         // --- Inicialización ---
         document.addEventListener('DOMContentLoaded', () => {
             loadFromLocalStorage();
-            generateNumbers(100);
             startMatrixAnimation();
         });
 


### PR DESCRIPTION
The application state, including the list of all numbers, is now saved to the browser's localStorage. When the page is reloaded, this state is restored, so any changes made by the user (adding or removing numbers) are preserved across sessions.

This change modifies:
- `saveToLocalStorage()` to include `allNumbers` in the saved data.
- `loadFromLocalStorage()` to retrieve `allNumbers` and handle initialization.
- The `DOMContentLoaded` listener to use the new loading logic.