### PR TITLE
fix: Correct search input clearing logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,12 +982,18 @@
         }
 
         // --- Lógica de Búsqueda ---
+        function clearHighlight() {
+            const highlighted = participantsList.querySelector('.person-entry.highlight');
+            if (highlighted) {
+                highlighted.classList.remove('highlight');
+            }
+        }
+
         function searchByNumber() {
-            clearSearch();
+            clearHighlight(); // Corrected: only clears previous highlight
             const numberToFind = parseInt(searchInput.value.trim(), 10);
 
             if (isNaN(numberToFind)) {
-                // No alert for empty input, just return silently
                 if (searchInput.value.trim() !== '') {
                     alert('Por favor, introduce un número válido.');
                 }
@@ -1015,10 +1021,7 @@
         }
 
         function clearSearch() {
-            const highlighted = participantsList.querySelector('.person-entry.highlight');
-            if (highlighted) {
-                highlighted.classList.remove('highlight');
-            }
+            clearHighlight();
             searchInput.value = '';
         }
 


### PR DESCRIPTION
This commit fixes a bug in the search functionality where the search input value was cleared before it could be read, causing the search to fail silently.

The code has been refactored to separate the logic for clearing the search highlight from the logic for clearing the input field.

- A new `clearHighlight()` function has been created.
- `searchByNumber()` now calls `clearHighlight()` to ensure the input value is preserved during the search.
- `clearSearch()` now calls `clearHighlight()` and clears the input, and is used only by the "Clear" button.